### PR TITLE
Feat(scalar): Configuration and Readme

### DIFF
--- a/scalar/README.md
+++ b/scalar/README.md
@@ -1,5 +1,72 @@
 # Scalar
 
+## Usage
+1. Add the swagger comment following this [reference](https://github.com/swaggo/swag#declarative-comments-format)
+2. Download Swag command latest
+```bash
+go install github.com/swaggo/swag/v2/cmd/swag@v2.0.0-rc4
 ```
+3. Use Swag command from 2. to generate the openAPI 3.1 docs
+```bash
+swag init -v3.1 -o docs -g main.go --parseDependency --parseInternal
+```
+4. Download Scalar UI package
+```bash
 go get github.com/yokeTH/go-pkg/scalar
+```
+And use as the fiber handler to your project
+```go
+package main
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/yokeTH/go-pkg/scalar"
+)
+
+//	@title Scalar Example
+//	@version 1.0
+//	@servers https http
+func main() {
+	app := fiber.New()
+
+	app.Get("/swagger/*", scalar.HandlerDefault)
+
+	app.Get("/swagger/*", scalar.New(scalar.Config{
+		// if your generate docs output path is not docs
+		DocsJsonPath: "./doc/swagger.json",
+	}))
+
+	app.Listen(":8080")
+}
+```
+
+## Config
+```go
+type Config struct {
+	// Title tag of html scalar
+	// default: "Scalar API Reference"
+	Title string
+
+	// Json string of OPEN API
+	// default: ""
+	DocsJsonContent string
+
+	// Url of json content
+	// example: app.Get("/swagger/*", scalar.HandlerDefault) -> /swagger/doc.json will serve the json of openAPI
+	// default: "doc.json"
+	DocsJsonUrl string
+
+	// Path of generated docs
+	// default: "./docs/swagger.json"
+	DocsJsonPath string
+
+	// Custom Scalar Style
+	// Ref: https://github.com/scalar/scalar/blob/main/packages/themes/src/variables.css
+	// default: ""
+	CustomStyle template.CSS
+
+	// Proxy to avoid CORS issues
+	// default: "https://proxy.scalar.com"
+	ProxyUrl string
+}
 ```

--- a/scalar/config.go
+++ b/scalar/config.go
@@ -1,0 +1,59 @@
+package scalar
+
+import "html/template"
+
+type Config struct {
+	// Title tag of html scalar
+	// default: "Scalar API Reference"
+	Title string
+
+	// Json string of OPEN API
+	// default: ""
+	DocsJsonContent string
+
+	// Url of json content
+	// default: "doc.json"
+	DocsJsonUrl string
+
+	// Path of generated docs
+	// default: "./docs/swagger.json"
+	DocsJsonPath string
+
+	// Custom Scalar Style
+	// Ref: https://github.com/scalar/scalar/blob/main/packages/themes/src/variables.css
+	// default: ""
+	CustomStyle template.CSS
+
+	// Proxy to avoid CORS issues
+	// default: "https://proxy.scalar.com"
+	ProxyUrl string
+}
+
+var defaultConfig = Config{
+	Title:        "Scalar API Reference",
+	DocsJsonUrl:  "doc.json",
+	DocsJsonPath: "./docs/swagger.json",
+	ProxyUrl:     "https://proxy.scalar.com",
+}
+
+func loadDefaultConfig(config Config) Config {
+	var cfg Config = defaultConfig
+
+	if config.Title != "" {
+		cfg.Title = config.Title
+	}
+
+	if config.DocsJsonUrl != "" {
+		cfg.DocsJsonUrl = config.DocsJsonPath
+	}
+
+	if config.DocsJsonPath != "" {
+		cfg.DocsJsonPath = config.DocsJsonPath
+	}
+
+	if config.ProxyUrl != "" {
+		cfg.ProxyUrl = config.ProxyUrl
+	}
+
+	return cfg
+}

--- a/scalar/config.go
+++ b/scalar/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	DocsJsonContent string
 
 	// Url of json content
+	// example: app.Get("/swagger/*", scalar.HandlerDefault) -> /swagger/doc.json will serve the json of openAPI
 	// default: "doc.json"
 	DocsJsonUrl string
 

--- a/scalar/index.go
+++ b/scalar/index.go
@@ -1,17 +1,21 @@
 package scalar
 
-import "fmt"
-
-func getHtmlByContent(content string) string {
-	return fmt.Sprintf(`
+const templeteHTML = `
 	<!doctype html>
 <html>
   <head>
-    <title>Scalar API Reference</title>
+    <title>{{.Title}}</title>
     <meta charset="utf-8" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1" />
+      	{{- if .CustomStyle}}
+       	<style>
+       	:root {
+       	{{ .CustomStyle }}
+       	}
+		</style>
+        {{end}}
   </head>
 
   <body>
@@ -23,12 +27,12 @@ func getHtmlByContent(content string) string {
     <!-- Initialize the Scalar API Reference -->
     <script>
       Scalar.createApiReference('#app', {
-        // The URL of the OpenAPI/Swagger document
-        content: %q,
+        // The content of the OpenAPI/Swagger document
+        content: {{.DocsJsonContent}},
+
         // Avoid CORS issues
-        proxyUrl: 'https://proxy.scalar.com',
+        proxyUrl: {{.ProxyUrl}},
       })
     </script>
   </body>
-</html>`, content)
-}
+</html>`

--- a/scalar/scalar.go
+++ b/scalar/scalar.go
@@ -2,38 +2,46 @@ package scalar
 
 import (
 	"fmt"
+	"html/template"
 	"os"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
 )
 
-const (
-	docsPathJson = "./docs/swagger.json"
-)
+var DefaultHandler = New()
 
-var DefaultHandler = new(docsPathJson)
+func New(config ...Config) fiber.Handler {
+	var cfg Config = defaultConfig
+	if len(config) > 1 {
+		cfg = loadDefaultConfig(config[0])
+	}
 
-func Handler(path string) fiber.Handler {
-	return new(path)
-}
-
-func new(docsPath string) fiber.Handler {
 	return func(ctx *fiber.Ctx) error {
-		_, err := os.Stat(docsPath)
-		if os.IsNotExist(err) {
-			return fmt.Errorf("%s file does not exist", docsPath)
+		if cfg.DocsJsonContent == "" {
+			_, err := os.Stat(cfg.DocsJsonPath)
+			if os.IsNotExist(err) {
+				return fmt.Errorf("%s file does not exist", cfg.DocsJsonPath)
+			}
+
+			rawSpec, err := os.ReadFile(cfg.DocsJsonPath)
+			if err != nil {
+				return fmt.Errorf("Failed to read provided Swagger file (%s): %v", cfg.DocsJsonPath, err.Error())
+			}
+
+			cfg.DocsJsonContent = string(rawSpec)
 		}
 
-		rawSpec, err := os.ReadFile(docsPath)
+		html, err := template.New("index.html").Parse(templeteHTML)
 		if err != nil {
-			return fmt.Errorf("Failed to read provided Swagger file (%s): %v", docsPath, err.Error())
+			return fmt.Errorf("Failed to parse html template:%v", err)
 		}
 
-		if strings.HasSuffix(ctx.Path(), "docs.json") {
-			return ctx.Type("json").Send(rawSpec)
+		if strings.HasSuffix(ctx.Path(), cfg.DocsJsonUrl) {
+			return ctx.Type("json").SendString(cfg.DocsJsonContent)
 		}
 
-		return ctx.Type("html").SendString(getHtmlByContent(string(rawSpec)))
+		ctx.Type("html")
+		return html.Execute(ctx, cfg)
 	}
 }


### PR DESCRIPTION
## Change
- add configuration allowing user to customization
- use `html/template` instead of string format
- moving reading to mounting handler to improve performance

# README

## Usage
1. Add the swagger comment following this [reference](https://github.com/swaggo/swag#declarative-comments-format)
2. Download Swag command latest
```bash
go install github.com/swaggo/swag/v2/cmd/swag@v2.0.0-rc4
```
3. Use Swag command from 2. to generate the openAPI 3.1 docs
```bash
swag init -v3.1 -o docs -g main.go --parseDependency --parseInternal
```
4. Download Scalar UI package
```bash
go get github.com/yokeTH/go-pkg/scalar
```
And use as the fiber handler to your project
```go
package main

import (
	"github.com/gofiber/fiber/v2"
	"github.com/yokeTH/go-pkg/scalar"
)

//	@title Scalar Example
//	@version 1.0
//	@servers https http
func main() {
	app := fiber.New()

	app.Get("/swagger/*", scalar.HandlerDefault)

	app.Get("/swagger/*", scalar.New(scalar.Config{
		// if your generate docs output path is not docs
		DocsJsonPath: "./doc/swagger.json",
	}))

	app.Listen(":8080")
}
```

## Config
```go
type Config struct {
	// Title tag of html scalar
	// default: "Scalar API Reference"
	Title string

	// Json string of OPEN API
	// default: ""
	DocsJsonContent string

	// Url of json content
	// example: app.Get("/swagger/*", scalar.HandlerDefault) -> /swagger/doc.json will serve the json of openAPI
	// default: "doc.json"
	DocsJsonUrl string

	// Path of generated docs
	// default: "./docs/swagger.json"
	DocsJsonPath string

	// Custom Scalar Style
	// Ref: https://github.com/scalar/scalar/blob/main/packages/themes/src/variables.css
	// default: ""
	CustomStyle template.CSS

	// Proxy to avoid CORS issues
	// default: "https://proxy.scalar.com"
	ProxyUrl string
}
```
